### PR TITLE
chore: Restrict workflow token permission

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Ddedalus/poetry-auto-export/security/code-scanning/1](https://github.com/Ddedalus/poetry-auto-export/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege permissions unless overridden. For this workflow, `contents: read` is the best minimal setting and aligns with checkout + test execution needs without changing intended functionality.

**File to change:** `.github/workflows/test.yml`  
**Region to change:** after the `on:` trigger block and before `jobs:`.  
**What to add:**  
```yaml
permissions:
  contents: read
```
No imports, methods, or additional definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
